### PR TITLE
KEY_KEYBOARD not supported under Ubuntu

### DIFF
--- a/panasonic-hbtn.c
+++ b/panasonic-hbtn.c
@@ -75,7 +75,7 @@ static const struct key_entry panasonic_keymap[] = {
     { KE_KEY, 0x4, { KEY_SCREENLOCK } }, /* Screen lock */
     { KE_KEY, 0x6, { KEY_DIRECTION } }, /* Screen rotate */
     { KE_KEY, 0x8, { KEY_ENTER } }, /* Enter */
-    { KE_KEY, 0xA, { KEY_KEYBOARD } }, /* Soft keyboard */
+    { KE_KEY, 0xA, { KEY_MENU } }, /* XF86MenuKB */
     { KE_END, 0 }
 };
 


### PR DESCRIPTION
KEY_KEYBOARD doesn't trigger any keycode press in Ubuntu 15.10. I replaced it with KEY_MENU, which at least triggers XF86MenuKB keycode, which afterwards can be assigned to launch "onboard" on-screen keyboard app, in the keyboard shortcuts settings of the operating system.

Looking at Linux kernel source code, I couldn't find any other suitable constant to use for this function.
